### PR TITLE
Removed reference to VTK package in CMakeLists and fixed linking problem.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,5 +12,5 @@ set(CMAKE_CXX_COMPILER mpicxx)
 
 add_subdirectory(src)
 
-enable_testing()
-add_subdirectory(test)
+#enable_testing()
+#add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,5 +12,5 @@ set(CMAKE_CXX_COMPILER mpicxx)
 
 add_subdirectory(src)
 
-#enable_testing()
-#add_subdirectory(test)
+enable_testing()
+add_subdirectory(test)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,5 @@
 find_package(PETSc COMPONENTS CXX)
 
-find_package(VTK REQUIRED)
-include(${VTK_USE_FILE})
-
 include_directories(.)
 include_directories(3rdparty/tinyxml2)
 include_directories(parallelManagers)
@@ -66,10 +63,10 @@ add_library(ns-eof
         SimpleTimer.h
         Simulation.h
         Stencil.h)
+target_link_libraries(ns-eof ${PETSC_LIBRARIES})
 
 add_executable(ns main.cpp)
-
-target_link_libraries(ns ${PETSC_LIBRARIES} ${VTK_LIBRARIES} ns-eof)
+target_link_libraries(ns ns-eof)
 
 if(MPI_COMPILE_FLAGS)
     set_target_properties(ns PROPERTIES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_definitions (-DBOOST_TEST_DYN_LINK)
 add_executable (Test DummyTestSuite.cpp)
 target_link_libraries (Test
         ${PETSC_LIBRARIES}
-        ${VTK_LIBRARIES}
         ns-eof
         ${Boost_FILESYSTEM_LIBRARY}
         ${Boost_SYSTEM_LIBRARY}


### PR DESCRIPTION
NOTE: Test build has been disabled as it requires fixing.
NOTE: In CLion it may be required to pass PETSC_DIR and PETSC_ARCH variables to CMake explicitly by using -DPETSC_DIR=<path> -DPETSC_ARCH=<arch>.