### PR TITLE
Fix build of tests, which could not properly include PETSC.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+# Ignore VTK files
+*.vtk
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,8 @@
 find_package (Boost COMPONENTS unit_test_framework REQUIRED)
 
 include_directories (${TEST_SOURCE_DIR}/src
-        ${Boost_INCLUDE_DIRS})
+        ${Boost_INCLUDE_DIRS}
+        ${PETSC_INCLUDES})
 
 add_definitions (-DBOOST_TEST_DYN_LINK)
 


### PR DESCRIPTION
Without including PETSC explicitly in the tests/CMakeLists.txt I was getting build errors when tests attempted to include any PETSC part.